### PR TITLE
Updated similarly to zim's equationeditor.py

### DIFF
--- a/templates/latexeditor.tex
+++ b/templates/latexeditor.tex
@@ -1,0 +1,15 @@
+\documentclass[[% font_size %]]{extarticle}
+\pagestyle{empty}
+[% IF dark_mode %]
+
+\usepackage{xcolor}
+[% END %]
+
+\begin{document}
+[% IF dark_mode %]
+\color{white}
+[% END %]
+
+
+
+\end{document}


### PR DESCRIPTION
I updated the plugin to be similarly to the [equationeditor.py](https://github.com/zim-desktop-wiki/zim-desktop-wiki/blob/develop/zim/plugins/equationeditor.py) from Zim.

I also took the freedom to provide a default text. I didn't know how Templates work, so I just provided the .tex file in the plugin folder. Users could manually edit it there.

Closes #1 